### PR TITLE
Update WidgetChart.jsx so that the bar chart displays correct Y value…

### DIFF
--- a/web/client/components/charts/WidgetChart.jsx
+++ b/web/client/components/charts/WidgetChart.jsx
@@ -278,9 +278,25 @@ const chartDataTypes = {
             }).filter(chart => chart !== null);
         }
         const sortedData = [...data].sort((a, b) => a[xDataKey] > b[xDataKey] ? 1 : -1);
-        const x = sortedData.map(d => d[xDataKey]);
-        const y = sortedData.map(d => d[yDataKey]);
+        
+        //changes that we made **********************************************************************
+        const aggregatedData = sortedData.reduce((acc, item) => {
+            const xValue = item[xDataKey];
+            const yValue = item[yDataKey];
+        
+            if (!acc[xValue])
+                acc[xValue] = 0;
+            acc[xValue] += yValue; // Summing up y-values for each unique x-value
+            return acc;
+        }, {});
+        
+        const x = Object.keys(aggregatedData);
+        const y = Object.values(aggregatedData);
+        // const x = sortedData.map(d => d[xDataKey]);
+        // const y = sortedData.map(d => d[yDataKey]);
+
         const name = traceName || yDataKey;
+        
         return {
             ...style,
             type: 'bar',


### PR DESCRIPTION
… on the onhover element

Recalculated how the onHover element for the bar chart is populated. Would sometimes take the first entry y value instead of adding it up for certain types of data. Now the onhover displays the accurate number for all bar charts

## Description

Fixing the on hover element for bar chart widget

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix


<!-- add here the ReadTheDocs link (if needed) -->

## Issue

**What is the current behavior?**
<!-- You can also link to an existing issue here -->
#<issue>

Onhover element for the bar chart widget will sometimes display the incorrect Y value depending on the type of data

**What is the new behavior?**

Recalculated how the onhover element / y value is populated so now it displays correctly for all bar charts

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)

 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications -->

## Other useful information
